### PR TITLE
Enable access-control on Trino chart

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "358"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 1.1.3
+version: 1.1.4
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![AppVersion: 358](https://img.shields.io/badge/AppVersion-358-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 358](https://img.shields.io/badge/AppVersion-358-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -21,6 +21,7 @@ High performance, distributed SQL query engine for big data
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| accessControl | object | `{}` |  |
 | affinity | object | `{}` |  |
 | auth | object | `{}` |  |
 | connectors | object | `{}` |  |
@@ -33,7 +34,7 @@ High performance, distributed SQL query engine for big data
 | resources | object | `{}` |  |
 | schemas | object | `{}` |  |
 | server.config.http.port | int | `8080` |  |
-| server.config.path | string | `"/etc/trino/"` |  |
+| server.config.path | string | `"/etc/trino"` |  |
 | server.config.processForwarded | bool | `false` |  |
 | server.config.query.maxMemory | string | `"3GB"` |  |
 | server.config.query.maxMemoryPerNode | string | `"1GB"` |  |

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -52,6 +52,13 @@ data:
     file.password-file={{ .Values.server.config.path }}/auth/password.db
 {{- end }}{{- end }}
 
+{{- if .Values.accessControl }}{{- if .Values.accessControl.type }}
+  access-control.properties: |
+    access-control.name=file
+    security.refresh-period={{ .Values.accessControl.refreshPeriod | default "1s" }}
+    security.config-file={{ .Values.server.config.path }}/access-control/{{ .Values.accessControl.configFile | default "rules.json" }}
+{{- end }}{{- end }}
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -64,5 +71,21 @@ data:
   {{- range $key, $val := .Values.schemas }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
+
+---
+
+{{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trino-access-control-volume-coordinator
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+data:
+  {{- range $key, $val := .Values.accessControl.rules }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}{{- end }}
 
 ---

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -38,12 +38,22 @@ spec:
           secret:
             secretName: trino-password-authentication
         {{- end }}{{- end }}
+        {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
+        - name: access-control-volume
+          configMap:
+            name: trino-access-control-volume-coordinator
+        {{- end }}{{- end }}
+        {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "pvc" }}
+        - name: access-control-pvc-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.accessControl.pvcName }}
+        {{- end }}{{- end }}
       containers:
         - name: {{ .Chart.Name }}-coordinator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
-            - mountPath: {{ .Values.server.config.path }}
+            - mountPath: {{ .Values.server.config.path }}/
               name: config-volume
             - mountPath: /etc/trino/schemas
               name: schemas-volume
@@ -52,7 +62,15 @@ spec:
             {{- if .Values.server.config.authenticationType }}{{- if eq .Values.server.config.authenticationType "PASSWORD" }}
             - mountPath: {{ .Values.server.config.path }}/auth
               name: password-volume
-            {{- end }}{{- end }}              
+            {{- end }}{{- end }}
+            {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
+            - mountPath: {{ .Values.server.config.path }}/access-control
+              name: access-control-volume
+            {{- end }}{{- end }}
+            {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "pvc" }}
+            - mountPath: {{ .Values.server.config.path }}/access-control
+              name: access-control-pvc-volume
+            {{- end }}{{- end }}
           ports:
             - name: http-coord
               containerPort: {{ .Values.server.config.http.port }}

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -16,7 +16,7 @@ server:
     trino:
       level: INFO
   config:
-    path: /etc/trino/
+    path: /etc/trino
     http:
       port: 8080
     processForwarded: false
@@ -39,6 +39,61 @@ auth: {}
   # Set username and password
   # https://trino.io/docs/current/security/password-file.html#file-format
   # passwordAuth: "username:encrypted-password-with-htpasswd"
+
+accessControl: {}
+  # # Supported types: pvc or configmap
+  # type: pvc
+  # refreshPeriod: 1s
+  # # Rules file is mounted to /etc/trino/access-control
+  # configFile: "/access-control/rules.json"
+  # # If you use pvc as the type, you have to specify the pvcName field:
+  # pvcName:
+  # # If you use configmap as the type, you have to specify the rules field:
+  # rules:
+  #   rules.json: |-
+  #     {
+  #       "catalogs": [
+  #         {
+  #           "user": "admin",
+  #           "catalog": "(mysql|system)",
+  #           "allow": "all"
+  #         },
+  #         {
+  #           "group": "finance|human_resources",
+  #           "catalog": "postgres",
+  #           "allow": true
+  #         },
+  #         {
+  #           "catalog": "hive",
+  #           "allow": "all"
+  #         },
+  #         {
+  #           "user": "alice",
+  #           "catalog": "postgresql",
+  #           "allow": "read-only"
+  #         },
+  #         {
+  #           "catalog": "system",
+  #           "allow": "none"
+  #         }
+  #       ],
+  #       "schemas": [
+  #         {
+  #           "user": "admin",
+  #           "schema": ".*",
+  #           "owner": true
+  #         },
+  #         {
+  #           "user": "guest",
+  #           "owner": false
+  #         },
+  #         {
+  #           "catalog": "default",
+  #           "schema": "default",
+  #           "owner": true
+  #         }
+  #       ]
+  #     }
 
 connectors: {}
   # Connectors configuration usually contains sensitive data (like passwords, usernames, ...)


### PR DESCRIPTION
This PR makes it possible to enable access-control with rules on Trino: 

https://trino.io/docs/current/security/file-system-access-control.html

There are two options:
1. Adding rules json file into configmap and mounting this configmap 
2. Adding rules json file into PVC and mounting this PVC