### PR TITLE
upgrade trino version to 380

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "378"
+appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 2.2.1
+version: 2.2.2
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![AppVersion: 378](https://img.shields.io/badge/AppVersion-378-informational?style=flat-square)
+![Version: 2.2.2](https://img.shields.io/badge/Version-2.2.2-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -75,7 +75,7 @@ High performance, distributed SQL query engine for big data
 | image.repository | string | `"trinodb/trino"` |  |
 | image.securityContext.runAsGroup | int | `1000` |  |
 | image.securityContext.runAsUser | int | `1000` |  |
-| image.tag | int | `378` |  |
+| image.tag | int | `380` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: trinodb/trino
-  tag: 378
+  tag: 380
   pullPolicy: IfNotPresent
   securityContext:
     runAsUser: 1000


### PR DESCRIPTION
Trino 380 solves the problems of accessing hive views if they are created using hive or AWS athena, upgrading to 380 will solve this issue in hive connector.
https://trino.io/docs/current/release/release-380.html