### PR TITLE
Full support for custom group provider

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 2.4.1
+version: 2.4.2
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -76,15 +76,15 @@ data:
     resource-groups.config-file={{ .Values.config.general.path }}/resource-groups/{{ .Values.resourceGroups.configFile | default "resource-groups.json" }}
 {{- end }}{{- end }}
 
-{{- if .Values.groupProvider }}{{- if .Values.groupProvider.type }}{{- if .Values.groupProvider.name }}
+{{- if .Values.groupProvider }}{{- if .Values.groupProvider.type }}
   group-provider.properties: |
-    group-provider.name={{ .Values.groupProvider.name }}
+    group-provider.name={{ required "groupProvider requires a valid 'name'." .Values.groupProvider.name }}
 {{- if eq .Values.groupProvider.name "file" }}
     file.refresh-period={{ .Values.groupProvider.refreshPeriod | default "5s" }}
     file.group-file={{ .Values.config.general.path }}/group-provider/{{ .Values.groupProvider.configFile | default "groups.txt" }}
 {{- end }}
 {{ .Values.groupProvider.customProperties | indent 4 }}
-{{- end }}{{- end }}{{- end }}
+{{- end }}{{- end }}
 
 ---
 apiVersion: v1

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -78,9 +78,11 @@ data:
 
 {{- if .Values.groupProvider }}{{- if .Values.groupProvider.type }}
   group-provider.properties: |
-    group-provider.name=file
+    group-provider.name={{ .Values.groupProvider.name }}
+{{- if eq .Values.groupProvider.name "file" }}
     file.refresh-period={{ .Values.groupProvider.refreshPeriod | default "5s" }}
     file.group-file={{ .Values.config.general.path }}/group-provider/{{ .Values.groupProvider.configFile | default "groups.txt" }}
+{{- end }}
 {{ .Values.groupProvider.customProperties | indent 4 }}
 {{- end }}{{- end }}
 

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -76,7 +76,7 @@ data:
     resource-groups.config-file={{ .Values.config.general.path }}/resource-groups/{{ .Values.resourceGroups.configFile | default "resource-groups.json" }}
 {{- end }}{{- end }}
 
-{{- if .Values.groupProvider }}{{- if .Values.groupProvider.type }}
+{{- if .Values.groupProvider }}{{- if .Values.groupProvider.type }}{{- if .Values.groupProvider.name }}
   group-provider.properties: |
     group-provider.name={{ .Values.groupProvider.name }}
 {{- if eq .Values.groupProvider.name "file" }}
@@ -84,7 +84,7 @@ data:
     file.group-file={{ .Values.config.general.path }}/group-provider/{{ .Values.groupProvider.configFile | default "groups.txt" }}
 {{- end }}
 {{ .Values.groupProvider.customProperties | indent 4 }}
-{{- end }}{{- end }}
+{{- end }}{{- end }}{{- end }}
 
 ---
 apiVersion: v1

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -306,6 +306,7 @@ resourceGroups: {}
 
 groupProvider: {}
   # # Supported types: pvc or configmap
+  # name: file
   # type: pvc
   # refreshPeriod: 5s
   # # Rules file is mounted to /etc/trino/group-provider


### PR DESCRIPTION
Continuation of https://github.com/valeriano-manassero/helm-charts/pull/135: custom properties allow for a custom group provider but a custom group provider cannot be used at the same time as a file group provider.