### PR TITLE
fsGroup for deployment, not initContainer

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 2.5.0
+version: 2.5.1
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -26,6 +26,7 @@ spec:
       securityContext:
         runAsUser: {{ .runAsUser }}
         runAsGroup: {{ .runAsGroup }}
+        fsGroup: {{ .fsGroup }}
       {{- end }}
       volumes:
         - name: config-volume
@@ -106,7 +107,6 @@ spec:
           securityContext:
             runAsUser: {{ .runAsUser }}
             runAsGroup: {{ .runAsGroup }}
-            fsGroup: {{ .fsGroup }}
           {{- end }}
           command: [ /bin/bash ]
           args:


### PR DESCRIPTION
Small fix; I meant to add fsGroup in the securityContext of the deployment, not the initContainer (where it doesn't exist).