### PR TITLE
certs emptydir

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 2.5.1
+version: 2.5.2
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -54,9 +54,9 @@ spec:
           secret:
             secretName: {{ include "trino.tlsSecretName" . }}
             defaultMode: 0400
+        {{- end }}
         - name: certs-shared
           emptyDir: {}
-        {{- end }}
         {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
         - name: access-control-volume
           configMap:
@@ -185,10 +185,8 @@ spec:
             - mountPath: {{ .Values.config.general.path }}/auth
               name: password-volume
             {{- end }}{{- end }}
-            {{- if (include "trino.tlsEncryption" . ) }}
-            - name: certs-shared
-              mountPath: {{ .Values.config.general.path }}/certs
-            {{- end }}
+            - mountPath: {{ .Values.config.general.path }}/certs
+              name: certs-shared
             {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
             - mountPath: {{ .Values.config.general.path }}/access-control
               name: access-control-volume

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -49,6 +49,8 @@ spec:
         - name: schemas-volume
           configMap:
             name: schemas-volume-worker
+        - name: certs-shared
+          emptyDir: {}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:
@@ -83,6 +85,8 @@ spec:
               name: health-check-volume
             - mountPath: {{ .Values.config.general.path }}/catalog
               name: catalog-volume
+            - mountPath: {{ .Values.config.general.path }}/certs
+              name: certs-shared
             {{- range .Values.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}


### PR DESCRIPTION
This PR is to make it so there's always a "{{ .Values.config.general.path }}/certs" folder for initContainers. For example, if you need a truststore for a specific catalog, you would need to import or create your own cert in an initContainer for both the worker and the coordinator.