### PR TITLE
initContainers as lists

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 2.6.0
+version: 2.6.1
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -68,7 +68,7 @@ config:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
-    initContainers: {}
+    initContainers: []
     #   - name: init-coordinator
     #     image: busybox:1.28
     #     imagePullPolicy: IfNotPresent
@@ -97,7 +97,7 @@ config:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
-    initContainers: {}
+    initContainers: []
     # worker:
     #   - name: init-worker
     #     image: busybox:1.28


### PR DESCRIPTION
`coalesce.go:199: warning: cannot overwrite table with non table for initContainers (map[])`
initContainers should be lists not dicts/objects.