### PR TITLE
support multiple configurations as an object not a single string

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 2.8.1
+version: 2.8.2
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 2.8.2
+version: 3.0.0
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 2.8.1](https://img.shields.io/badge/Version-2.8.1-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
+![Version: 2.8.2](https://img.shields.io/badge/Version-2.8.2-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -27,7 +27,7 @@ High performance, distributed SQL query engine for big data
 | clusterDomain | string | `"cluster.local"` |  |
 | config.coordinator.affinity | object | `{}` |  |
 | config.coordinator.env | list | `[]` |  |
-| config.coordinator.extraConfig | string | `""` |  |
+| config.coordinator.extraConfig | object | `{}` |  |
 | config.coordinator.initContainers | list | `[]` |  |
 | config.coordinator.jvm.gcMethod.g1.heapRegionSize | string | `"32M"` |  |
 | config.coordinator.jvm.gcMethod.type | string | `"UseG1GC"` |  |
@@ -62,7 +62,7 @@ High performance, distributed SQL query engine for big data
 | config.worker.autoscaler.stabilizationWindowSeconds | int | `300` |  |
 | config.worker.autoscaler.targetCPUUtilizationPercentage | int | `50` |  |
 | config.worker.env | list | `[]` |  |
-| config.worker.extraConfig | string | `""` |  |
+| config.worker.extraConfig | object | `{}` |  |
 | config.worker.initContainers | list | `[]` |  |
 | config.worker.jvm.gcMethod.g1.heapRegionSize | string | `"32M"` |  |
 | config.worker.jvm.gcMethod.type | string | `"UseG1GC"` |  |

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 2.8.2](https://img.shields.io/badge/Version-2.8.2-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -55,7 +55,9 @@ data:
 {{- if .Values.config.general.internalCommunicationSharedSecret }}
     internal-communication.shared-secret={{ .Values.config.general.internalCommunicationSharedSecret }}
 {{- end }}
-{{ .Values.config.coordinator.extraConfig | indent 4 }}
+{{- range $configValue := .Values.config.coordinator.extraConfig }}
+    {{ $configValue }}
+{{- end }}
 
   log.properties: |
     io.trino={{ .Values.config.general.log.trino.level }}

--- a/valeriano-manassero/trino/templates/configmap-worker.yaml
+++ b/valeriano-manassero/trino/templates/configmap-worker.yaml
@@ -40,7 +40,9 @@ data:
 {{- if .Values.config.general.internalCommunicationSharedSecret }}
     internal-communication.shared-secret={{ .Values.config.general.internalCommunicationSharedSecret }}
 {{- end }}
-{{ .Values.config.worker.extraConfig | indent 4 }}
+{{- range $configValue := .Values.config.coordinator.extraConfig }}
+    {{ $configValue }}
+{{- end }}
 
   log.properties: |
     io.trino={{ .Values.config.general.log.trino.level }}

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -80,7 +80,9 @@ config:
         g1:
           heapRegionSize: "32M"
     jvmExtraConfig: ""
-    extraConfig: ""
+    extraConfig: {}
+    #  - "retry-policy=TASK"
+    #  - "exchange.compression-enabled=true"
 
   worker:
     # -- Replica count when autoscaler is disabled. If autoscaler is enabled, it sets minimum number of replicas.
@@ -109,7 +111,9 @@ config:
         g1:
           heapRegionSize: "32M"
     jvmExtraConfig: ""
-    extraConfig: ""
+    extraConfig: {}
+    #  - "retry-policy=TASK"
+    #  - "exchange.compression-enabled=true"
     autoscaler:
       enabled: false
       maxReplicas: 5


### PR DESCRIPTION
Hello,
I was trying to add some additional configurations such as below:

```
retry-policy=TASK
query.hash-partition-count=50
```
But it adds both properties in a single line as `extraConfig: ""` is a string value. We should make it an object and store all extra configuration in config.properties as it is given by the user.

This PR fixes issue #150 