### PR TITLE
move podAnnotations to coord and worker

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 4.0.0
+version: 4.0.1
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -18,7 +18,7 @@ spec:
         app.kubernetes.io/component: coordinator
       annotations:
         checksum/config: {{ printf "%s%s" (include (print $.Template.BasePath "/configmap-coordinator.yaml") .) (include (print $.Template.BasePath "/secret.yaml") .) | sha256sum }}
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.config.coordinator.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/component: worker
       annotations:
         checksum/config: {{ printf "%s%s" (include (print $.Template.BasePath "/configmap-worker.yaml") .) (include (print $.Template.BasePath "/secret.yaml") .) | sha256sum }}
-    {{- with .Values.podAnnotations }}
+    {{- with .Values.config.worker.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:


### PR DESCRIPTION
The proposed solution changes .Values.podAnnotations to .Values.config.worker-coordinator.podAnnotations. so we can have different options and annotations for them.
https://github.com/valeriano-manassero/helm-charts/issues/153

