### PR TITLE
enable multi-cluster on the same namespace

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 4.0.1
+version: 4.0.2
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "380"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 4.0.2
+version: 4.1.0
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
+![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ![AppVersion: 380](https://img.shields.io/badge/AppVersion-380-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -77,6 +77,7 @@ High performance, distributed SQL query engine for big data
 | connectors | object | `{}` |  |
 | eventListenerProperties | object | `{}` |  |
 | faultTolerance.enabled | bool | `false` |  |
+| fullnameOverride | string | `"trino"` |  |
 | groupProvider | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"trinodb/trino"` |  |

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -106,7 +106,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: schemas-volume-coordinator
+  name: {{ template "trino.fullname" . }}-schemas-volume-coordinator
   labels:
     {{- include "trino.labels" . | nindent 4 }}
     app.kubernetes.io/component: coordinator

--- a/valeriano-manassero/trino/templates/configmap-worker.yaml
+++ b/valeriano-manassero/trino/templates/configmap-worker.yaml
@@ -74,7 +74,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: schemas-volume-worker
+  name: {{ template "trino.fullname" . }}-schemas-volume-worker
   labels:
     {{- include "trino.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -43,7 +43,7 @@ spec:
         {{- end }}
         - name: schemas-volume
           configMap:
-            name: schemas-volume-coordinator
+            name: {{ template "trino.fullname" . }}-schemas-volume-coordinator
         {{- if .Values.config.general.authenticationType }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
         - name: password-volume
           secret:

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
         - name: schemas-volume
           configMap:
-            name: schemas-volume-worker
+            name: {{ template "trino.fullname" . }}-schemas-volume-worker
         - name: certs-shared
           emptyDir: {}
         {{- if .Values.jmxExporter.worker.enabled }}

--- a/valeriano-manassero/trino/templates/secret.yaml
+++ b/valeriano-manassero/trino/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: trino-connectors
+  name: {{ template "trino.fullname" . }}-connectors
   labels:
     {{- include "trino.labels" . | nindent 4 }}
 data:
@@ -16,7 +16,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: trino-password-authentication
+  name: {{ template "trino.fullname" . }}-password-authentication
   labels:
     {{- include "trino.labels" . | nindent 4 }}
 data:

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -7,6 +7,8 @@ image:
     runAsGroup: 1000
     fsGroup: 1000
 
+fullnameOverride: trino
+
 imagePullSecrets: []
 # For example:
 # imagePullSecrets:


### PR DESCRIPTION
The proposed change allows us to deploy two deployments within the same Kubernetes namespace. The change was based on a fullname template variable with is being used in the jmx-exporter reference. As an example:

https://github.com/valeriano-manassero/helm-charts/issues/158

https://github.com/valeriano-manassero/helm-charts/blob/feb358572f69213480f63576f271945d4c866593/valeriano-manassero/trino/templates/deployment-worker.yaml#L56-L57

@valeriano-manassero what do you think?