### PR TITLE
Split maxMemoryPerNode config to coordinator and worker

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "419"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 4.3.0
+version: 5.0.0
 kubeVersion: ">= 1.25.0-0 < 1.28.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
@@ -27,4 +27,4 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Trino app version to 419
+      description: Split maxMemoryPerNode config to coordinator and worker

--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "419"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 4.2.0
+version: 4.3.0
 kubeVersion: ">= 1.25.0-0 < 1.28.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
+![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -39,6 +39,7 @@ Kubernetes: `>= 1.25.0-0 < 1.28.0-0`
 | config.coordinator.jvmExtraConfig | string | `""` |  |
 | config.coordinator.nodeSelector | object | `{}` |  |
 | config.coordinator.podAnnotations | object | `{}` |  |
+| config.coordinator.query.maxMemoryPerNode | string | `"1GB"` |  |
 | config.coordinator.replicas | int | `1` |  |
 | config.coordinator.resources | object | `{}` |  |
 | config.coordinator.tolerations | list | `[]` |  |
@@ -58,7 +59,6 @@ Kubernetes: `>= 1.25.0-0 < 1.28.0-0`
 | config.general.prestoCompatibleHeader | bool | `false` |  |
 | config.general.processForwarded | bool | `false` |  |
 | config.general.query.maxMemory | string | `"3GB"` |  |
-| config.general.query.maxMemoryPerNode | string | `"1GB"` |  |
 | config.general.query.maxTotalMemory | string | `"6GB"` |  |
 | config.worker.affinity | object | `{}` |  |
 | config.worker.autoscaler.enabled | bool | `false` |  |
@@ -74,6 +74,7 @@ Kubernetes: `>= 1.25.0-0 < 1.28.0-0`
 | config.worker.jvmExtraConfig | string | `""` |  |
 | config.worker.nodeSelector | object | `{}` |  |
 | config.worker.podAnnotations | object | `{}` |  |
+| config.worker.query.maxMemoryPerNode | string | `"1GB"` |  |
 | config.worker.replicas | int | `2` | Replica count when autoscaler is disabled. If autoscaler is enabled, it sets minimum number of replicas. |
 | config.worker.resources | object | `{}` |  |
 | config.worker.tolerations | list | `[]` |  |

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -41,7 +41,7 @@ data:
     http-server.authentication.type={{ .Values.config.general.authenticationType }}
 {{- end }}
     query.max-memory={{ .Values.config.general.query.maxMemory }}
-    query.max-memory-per-node={{ .Values.config.general.query.maxMemoryPerNode }}
+    query.max-memory-per-node={{ .Values.config.coordinator.query.maxMemoryPerNode }}
     query.max-total-memory={{ .Values.config.general.query.maxTotalMemory }}
     discovery.uri=http://localhost:{{ .Values.config.general.http.port }}
 {{- if .Values.config.general.prestoCompatibleHeader }}

--- a/valeriano-manassero/trino/templates/configmap-worker.yaml
+++ b/valeriano-manassero/trino/templates/configmap-worker.yaml
@@ -31,7 +31,7 @@ data:
     coordinator=false
     http-server.http.port={{ .Values.config.general.http.port }}
     query.max-memory={{ .Values.config.general.query.maxMemory }}
-    query.max-memory-per-node={{ .Values.config.general.query.maxMemoryPerNode }}
+    query.max-memory-per-node={{ .Values.config.worker.query.maxMemoryPerNode }}
     query.max-total-memory={{ .Values.config.general.query.maxTotalMemory }}
     discovery.uri=http://{{ template "trino.fullname" . }}:{{ .Values.config.general.http.port }}
 {{- if .Values.config.general.prestoCompatibleHeader }}

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -52,7 +52,6 @@ config:
     internalCommunicationSharedSecret: some-secret
     query:
       maxMemory: "3GB"
-      maxMemoryPerNode: "1GB"
       maxTotalMemory: "6GB"
     prestoCompatibleHeader: false
 
@@ -83,6 +82,8 @@ config:
           heapRegionSize: "32M"
     jvmExtraConfig: ""
     extraConfig: ""
+    query:
+      maxMemoryPerNode: "1GB"
 
   worker:
     # -- Replica count when autoscaler is disabled. If autoscaler is enabled, it sets minimum number of replicas.
@@ -112,6 +113,8 @@ config:
           heapRegionSize: "32M"
     jvmExtraConfig: ""
     extraConfig: ""
+    query:
+      maxMemoryPerNode: "1GB"
     autoscaler:
       enabled: false
       maxReplicas: 5


### PR DESCRIPTION
Trino expects `query.max-total-memory-per-node` + `memory.heap-headroom-per-node` < `maxHeapSize`. Since `query.maxMemoryPerNode` was being attributed as a global value, and we configure `query.max-total-memory-per-node` accordingly to the worker, we were having problems to configure the coordinator maxHeapSize properly. 

Splitting this configuration between worker and coordinator is something that the official chart already [does](https://github.com/trinodb/charts/blob/main/charts/trino/values.yaml#LL160C24-L160C24). I believe it is a important feature to add.