### PR TITLE
Add jvm extra configs

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "419"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 5.0.0
+version: 5.1.0
 kubeVersion: ">= 1.25.0-0 < 1.28.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
@@ -27,4 +27,4 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Split maxMemoryPerNode config to coordinator and worker
+      description: Add extra jvm configs

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
+![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -21,6 +21,13 @@ data:
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
     -Djdk.attach.allowAttachSelf=true
+    -XX:-UseBiasedLocking
+    -XX:ReservedCodeCacheSize=512M
+    -XX:PerMethodRecompilationCutoff=10000
+    -XX:PerBytecodeRecompilationCutoff=10000
+    -Djdk.nio.maxCachedBufferSize=2000000
+    -XX:+UnlockDiagnosticVMOptions
+    -XX:+UseAESCTRIntrinsics
 {{- if .Values.jmxExporter.coordinator.enabled }}
     -javaagent:{{ .Values.jmxExporter.path }}/lib/{{ .Values.jmxExporter.jarfile }}={{ .Values.jmxExporter.port }}:{{ .Values.jmxExporter.path }}/etc/trino.yaml
 {{- end }}

--- a/valeriano-manassero/trino/templates/configmap-worker.yaml
+++ b/valeriano-manassero/trino/templates/configmap-worker.yaml
@@ -22,6 +22,13 @@ data:
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
     -Djdk.attach.allowAttachSelf=true
+    -XX:-UseBiasedLocking
+    -XX:ReservedCodeCacheSize=512M
+    -XX:PerMethodRecompilationCutoff=10000
+    -XX:PerBytecodeRecompilationCutoff=10000
+    -Djdk.nio.maxCachedBufferSize=2000000
+    -XX:+UnlockDiagnosticVMOptions
+    -XX:+UseAESCTRIntrinsics
 {{- if .Values.jmxExporter.worker.enabled }}
     -javaagent:{{ .Values.jmxExporter.path }}/lib/{{ .Values.jmxExporter.jarfile }}={{ .Values.jmxExporter.port }}:{{ .Values.jmxExporter.path }}/etc/trino.yaml
 {{- end }}


### PR DESCRIPTION
Noticed that some jvm configs were not being declared on the worker and also on the coordinator. Since they are declared [here](https://github.com/trinodb/charts/blob/main/charts/trino/templates/configmap-worker.yaml#L31-L37) I believe we should be adding those also.