### PR TITLE
Fix wrong number of args for contains

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "419"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 5.1.1
+version: 5.1.2
 kubeVersion: ">= 1.24.0-0 < 1.28.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
@@ -27,4 +27,4 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Restored 1.24 compatibility support
+      description: Fix wrong number of args for contains

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 5.1.1](https://img.shields.io/badge/Version-5.1.1-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
+![Version: 5.1.2](https://img.shields.io/badge/Version-5.1.2-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -67,7 +67,7 @@ data:
   log.properties: |
     io.trino={{ .Values.config.general.log.trino.level }}
 
-{{- if .Values.config.general.authenticationType }}{{- if contains "PASSWORD" eq .Values.config.general.authenticationType }}
+{{- if .Values.config.general.authenticationType }}{{- if contains "PASSWORD" .Values.config.general.authenticationType }}
   password-authenticator.properties: |
     password-authenticator.name=file
     file.password-file={{ .Values.config.general.path }}/auth/password.db


### PR DESCRIPTION
Apparently, we were passing 3 args to the contains function instead of 2