### PR TITLE
Password authenticator properties

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "419"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 5.1.2
+version: 5.1.3
 kubeVersion: ">= 1.24.0-0 < 1.28.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
@@ -26,5 +26,5 @@ keywords:
   - "high performance"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix wrong number of args for contains
+    - kind: added
+      description: Password authenticator properties

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -44,7 +44,6 @@ Kubernetes: `>= 1.24.0-0 < 1.28.0-0`
 | config.coordinator.resources | object | `{}` |  |
 | config.coordinator.tolerations | list | `[]` |  |
 | config.general.authenticationType | string | `""` | Trino supports multiple authentication types: PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS For more info: https://trino.io/docs/current/security/authentication-types.html |
-| config.passwordAuthenticatorProperties | object | `{}` | If `config.general.authenticationType` is `PASSWORD`, you can customize here `password-authenticator.properties` content for authenticators ldap or salesforce. Otherewise content is `file` and password file is `/auth/password.db` in `config.general.path` |
 | config.general.catalogsMountType | string | `"secret"` |  |
 | config.general.http.port | int | `8080` |  |
 | config.general.httpsServer.enabled | bool | `false` |  |

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 5.1.2](https://img.shields.io/badge/Version-5.1.2-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
+![Version: 5.1.3](https://img.shields.io/badge/Version-5.1.3-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -115,6 +115,7 @@ Kubernetes: `>= 1.24.0-0 < 1.28.0-0`
 | jmxExporter.serviceMonitor.port | string | `"jmx-exporter"` |  |
 | jmxExporter.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | jmxExporter.worker.enabled | bool | `false` |  |
+| passwordAuthenticatorProperties | object | `{}` | Password authenticator configuration, an item per conf line. Requiere `config.general.authenticationType` set to `PASSWORD`. For file : you don't need to use this propertie if you set `config.general.authenticationType` to `PASSWORD` and use `config.auth` to fill `auth/password.db`. For LDAP : https://trino.io/docs/current/security/ldap.html. For SalesForce : https://trino.io/docs/current/security/salesforce.html |
 | resourceGroups | object | `{}` |  |
 | schemas | object | `{}` |  |
 | secretMounts | list | `[]` |  |

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -44,6 +44,7 @@ Kubernetes: `>= 1.24.0-0 < 1.28.0-0`
 | config.coordinator.resources | object | `{}` |  |
 | config.coordinator.tolerations | list | `[]` |  |
 | config.general.authenticationType | string | `""` | Trino supports multiple authentication types: PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS For more info: https://trino.io/docs/current/security/authentication-types.html |
+| config.passwordAuthenticatorProperties | object | `{}` | If `config.general.authenticationType` is `PASSWORD`, you can customize here `password-authenticator.properties` content for authenticators ldap or salesforce. Otherewise content is `file` and password file is `/auth/password.db` in `config.general.path` |
 | config.general.catalogsMountType | string | `"secret"` |  |
 | config.general.http.port | int | `8080` |  |
 | config.general.httpsServer.enabled | bool | `false` |  |

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -67,10 +67,16 @@ data:
   log.properties: |
     io.trino={{ .Values.config.general.log.trino.level }}
 
-{{- if .Values.config.general.authenticationType }}{{- if contains "PASSWORD" .Values.config.general.authenticationType }}
+{{ if .Values.config.general.authenticationType }}{{ if contains "PASSWORD" .Values.config.general.authenticationType }}
   password-authenticator.properties: |
+  {{- if .Values.passwordAuthenticatorProperties }}
+    {{- range $configValue := .Values.passwordAuthenticatorProperties }}
+    {{ $configValue }}
+    {{- end }}
+  {{- else }}
     password-authenticator.name=file
     file.password-file={{ .Values.config.general.path }}/auth/password.db
+  {{- end }}
 {{- end }}{{- end }}
 
 {{- if .Values.accessControl }}{{- if .Values.accessControl.type }}

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -44,7 +44,7 @@ spec:
         - name: schemas-volume
           configMap:
             name: {{ template "trino.fullname" . }}-schemas-volume-coordinator
-        {{- if .Values.config.general.authenticationType }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
+        {{- if (and .Values.config.general.authenticationType (not .Values.passwordAuthenticatorProperties)) }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
         - name: password-volume
           secret:
             secretName: {{ template "trino.fullname" . }}-password-authentication
@@ -205,7 +205,7 @@ spec:
               name: schemas-volume
             - mountPath: {{ .Values.config.general.path }}/catalog
               name: catalog-volume
-            {{- if .Values.config.general.authenticationType }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
+            {{- if (and .Values.config.general.authenticationType (not .Values.passwordAuthenticatorProperties)) }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
             - mountPath: {{ .Values.config.general.path }}/auth
               name: password-volume
             {{- end }}{{- end }}

--- a/valeriano-manassero/trino/templates/secret.yaml
+++ b/valeriano-manassero/trino/templates/secret.yaml
@@ -12,7 +12,7 @@ data:
 {{- end }}
 {{- end }}
 ---
-{{- if .Values.config.general.authenticationType }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
+{{- if and .Values.config.general.authenticationType (not .Values.passwordAuthenticatorProperties) }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -123,6 +123,12 @@ config:
 
 eventListenerProperties: {}
 
+passwordAuthenticatorProperties: {}
+  # Password authenticator configuration. config.general.authenticationType MUST BE SET to PASSWORD
+  # for file : you don't need to use this propertie if you set config.general.authenticationType to PASSWORD and use config.auth to fill auth/password.db
+  # for LDAP : https://trino.io/docs/current/security/ldap.html
+  # for SalesForce : https://trino.io/docs/current/security/salesforce.html
+
 auth: {}
   # Set username and password
   # https://trino.io/docs/current/security/password-file.html#file-format

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -123,11 +123,11 @@ config:
 
 eventListenerProperties: {}
 
+# -- Password authenticator configuration, an item per conf line. Requiere `config.general.authenticationType` set to `PASSWORD`.
+# For file : you don't need to use this propertie if you set `config.general.authenticationType` to `PASSWORD` and use `config.auth` to fill `auth/password.db`.
+# For LDAP : https://trino.io/docs/current/security/ldap.html.
+# For SalesForce : https://trino.io/docs/current/security/salesforce.html
 passwordAuthenticatorProperties: {}
-  # Password authenticator configuration. config.general.authenticationType MUST BE SET to PASSWORD
-  # for file : you don't need to use this propertie if you set config.general.authenticationType to PASSWORD and use config.auth to fill auth/password.db
-  # for LDAP : https://trino.io/docs/current/security/ldap.html
-  # for SalesForce : https://trino.io/docs/current/security/salesforce.html
 
 auth: {}
   # Set username and password


### PR DESCRIPTION
Fix #169 

If `config.general.authenticationType` is `PASSWORD`, you can customize in `config.passwordAuthenticatorProperties` the `password-authenticator.properties` content for authenticators ldap or salesforce. Otherewise content is `file` and password file is `/auth/password.db` in `config.general.path`

