### PR TITLE
Add capabilities to use secrets for authentication and fault tolerance

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "419"
 description: High performance, distributed SQL query engine for big data
 name: trino
 version: 6.0.0
-kubeVersion: ">= 1.23.0-0 < 1.28.0-0"
+kubeVersion: ">= 1.24.0-0 < 1.28.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:
@@ -32,5 +32,3 @@ annotations:
       description: Capabilities to use a custom secret for fault tolerance
     - kind: changed
       description: How the fault tolerance properties are configured
-    - kind: changed
-      description: Minimal supported Kubernetes version

--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 appVersion: "419"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 5.1.3
-kubeVersion: ">= 1.24.0-0 < 1.28.0-0"
+version: 6.0.0
+kubeVersion: ">= 1.23.0-0 < 1.28.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:
@@ -27,4 +27,10 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Password authenticator properties
+      description: Capabilities to use a custom secret for password authentication
+    - kind: added
+      description: Capabilities to use a custom secret for fault tolerance
+    - kind: changed
+      description: How the fault tolerance properties are configured
+    - kind: changed
+      description: Minimal supported Kubernetes version

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -19,7 +19,7 @@ High performance, distributed SQL query engine for big data
 
 ## Requirements
 
-Kubernetes: `>= 1.23.0-0 < 1.28.0-0`
+Kubernetes: `>= 1.24.0-0 < 1.28.0-0`
 
 ## Values
 

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 5.1.3](https://img.shields.io/badge/Version-5.1.3-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
+![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -19,7 +19,7 @@ High performance, distributed SQL query engine for big data
 
 ## Requirements
 
-Kubernetes: `>= 1.24.0-0 < 1.28.0-0`
+Kubernetes: `>= 1.23.0-0 < 1.28.0-0`
 
 ## Values
 

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -102,12 +102,6 @@ data:
 {{ .Values.groupProvider.customProperties | indent 4 }}
 {{- end }}{{- end }}
 
-{{- if .Values.faultTolerance.enabled }}
-  exchange-manager.properties: |
-    exchange-manager.name=filesystem
-{{ .Values.faultTolerance.additionalProperties | indent 4 }}
-{{- end }}
-
 {{ if .Values.eventListenerProperties }}
   event-listener.properties: |
   {{- range $configValue := .Values.eventListenerProperties }}

--- a/valeriano-manassero/trino/templates/configmap-worker.yaml
+++ b/valeriano-manassero/trino/templates/configmap-worker.yaml
@@ -52,12 +52,6 @@ data:
   log.properties: |
     io.trino={{ .Values.config.general.log.trino.level }}
 
-{{- if .Values.faultTolerance.enabled }}
-  exchange-manager.properties: |
-    exchange-manager.name=filesystem
-{{ .Values.faultTolerance.additionalProperties | indent 4 }}
-{{- end }}
-
 {{ if .Values.eventListenerProperties }}
   event-listener.properties: |
   {{- range $configValue := .Values.eventListenerProperties }}

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -30,8 +30,15 @@ spec:
       {{- end }}
       volumes:
         - name: config-volume
-          configMap:
-            name: {{ template "trino.coordinator" . }}
+          projected:
+            sources:
+            - configMap:
+                name: {{ template "trino.coordinator" . }}
+
+            {{- if .Values.faultTolerance.enabled }}
+            - secret:
+                name: {{ .Values.faultToleranceSecret | default "trino-fault-tolerance" }}
+            {{- end }}
         {{- if eq .Values.config.general.catalogsMountType "configmap" }}
         - name: catalog-volume
           configMap:
@@ -93,11 +100,6 @@ spec:
             name: {{ template "trino.fullname" . }}-jmx-exporter
         - name: jmx-exporter-lib
           emptyDir: {}
-        {{- end }}
-        {{- if .Values.faultTolerance.enabled }}
-        - name: fault-tolerance-volume
-          secret:
-            secretName: {{ .Values.faultToleranceSecret | default "trino-fault-tolerance" }}
         {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -94,6 +94,11 @@ spec:
         - name: jmx-exporter-lib
           emptyDir: {}
         {{- end }}
+        {{- if .Values.faultTolerance.enabled }}
+        - name: fault-tolerance-volume
+          secret:
+            secretName: {{ .Values.faultToleranceSecret | default "trino-fault-tolerance" }}
+        {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -47,7 +47,7 @@ spec:
         {{- if (and .Values.config.general.authenticationType (not .Values.passwordAuthenticatorProperties)) }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
         - name: password-volume
           secret:
-            secretName: {{ template "trino.fullname" . }}-password-authentication
+            secretName: {{ .Values.authenticationSecret | default (printf "%s-password-authentication" (include "trino.fullname" .)) }}
         {{- end }}{{- end }}
         {{- if (include "trino.tlsEncryption" . ) }}
         - name: certs

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -81,8 +81,8 @@ spec:
           {{- end }}
           args:
             - "--output"
-            - "{{ .Values.jmxExporter.path }}/lib/{{ .Values.jmxExporter.jarfile }}" 
-            - "{{ .Values.jmxExporter.downloadLink }}" 
+            - "{{ .Values.jmxExporter.path }}/lib/{{ .Values.jmxExporter.jarfile }}"
+            - "{{ .Values.jmxExporter.downloadLink }}"
           volumeMounts:
           - name: jmx-exporter-lib
             mountPath: {{ .Values.jmxExporter.path }}/lib/

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -58,6 +58,11 @@ spec:
         - name: jmx-exporter-lib
           emptyDir: {}
         {{- end }}
+        {{- if .Values.faultTolerance.enabled }}
+        - name: fault-tolerance-volume
+          secret:
+            secretName: {{ .Values.faultToleranceSecret | default "trino-fault-tolerance" }}
+        {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -31,8 +31,15 @@ spec:
       {{- end }}
       volumes:
         - name: config-volume
-          configMap:
-            name: {{ template "trino.worker" . }}
+          projected:
+            sources:
+            - configMap:
+                name: {{ template "trino.worker" . }}
+
+            {{- if .Values.faultTolerance.enabled }}
+            - secret:
+                name: {{ .Values.faultToleranceSecret | default "trino-fault-tolerance" }}
+            {{- end }}
         - name: health-check-volume
           configMap:
             name: {{ template "trino.worker" . }}-health-check
@@ -57,11 +64,6 @@ spec:
             name: {{ template "trino.fullname" . }}-jmx-exporter
         - name: jmx-exporter-lib
           emptyDir: {}
-        {{- end }}
-        {{- if .Values.faultTolerance.enabled }}
-        - name: fault-tolerance-volume
-          secret:
-            secretName: {{ .Values.faultToleranceSecret | default "trino-fault-tolerance" }}
         {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}

--- a/valeriano-manassero/trino/templates/secret.yaml
+++ b/valeriano-manassero/trino/templates/secret.yaml
@@ -12,7 +12,7 @@ data:
 {{- end }}
 {{- end }}
 ---
-{{- if and .Values.config.general.authenticationType (not .Values.passwordAuthenticatorProperties) }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}
+{{- if and .Values.config.general.authenticationType (not .Values.passwordAuthenticatorProperties) }}{{- if eq .Values.config.general.authenticationType "PASSWORD" }}{{- if not .Values.authenticationSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,4 +21,4 @@ metadata:
     {{- include "trino.labels" . | nindent 4 }}
 data:
   password.db: {{ .Values.auth.passwordAuth | b64enc }}
-{{- end }}{{- end }}
+{{- end }}{{- end }}{{- end }}

--- a/valeriano-manassero/trino/templates/secret.yaml
+++ b/valeriano-manassero/trino/templates/secret.yaml
@@ -22,3 +22,15 @@ metadata:
 data:
   password.db: {{ .Values.auth.passwordAuth | b64enc }}
 {{- end }}{{- end }}{{- end }}
+---
+{{- if .Values.faultTolerance.enabled }}{{- if not .Values.faultToleranceSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trino-fault-tolerance
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+data:
+  exchange-manager.properties: |
+    {{ .Values.faultTolerance.properties | b64enc }}
+{{- end }}{{- end }}

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -321,6 +321,7 @@ resourceGroups: {}
 # If you want to provide your own secrets resource, you can use this field:
 # connectorsSecret:
 # authenticationSecret:
+# faultToleranceSecret:
 
 groupProvider: {}
   # # Supported types: pvc or configmap
@@ -343,7 +344,8 @@ groupProvider: {}
 
 faultTolerance:
   enabled: false
-  # additionalProperties: |-
+  # properties: |-
+  #   exchange-manager.name=filesystem
   #   exchange.base-directories=s3://<bucket-name>
   #   exchange.s3.region=us-east-1
   #   exchange.s3.aws-access-key=<access-key>

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -320,6 +320,7 @@ resourceGroups: {}
 
 # If you want to provide your own secrets resource, you can use this field:
 # connectorsSecret:
+# authenticationSecret:
 
 groupProvider: {}
   # # Supported types: pvc or configmap


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the capability to use custom secrets for authentication and enable fault tolerance in the same way it is currently done for connectors.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/valeriano-manassero/helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/valeriano-manassero/helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifacthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)