### PR TITLE
Allow Environment Variables to be defined for both coordinator and wo…

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "419"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 6.1.0
+version: 6.2.0
 kubeVersion: ">= 1.24.0-0 < 1.28.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
@@ -40,3 +40,5 @@ annotations:
       description: Added container envFrom
     - kind: fixed
       description: Password authentication secret rendering when multiple authentication types are configured
+    - kind: added
+      description: Allow Environment Variables to be defined for both coordinator and workers in the same place

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 6.1.0](https://img.shields.io/badge/Version-6.1.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
+![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![AppVersion: 419](https://img.shields.io/badge/AppVersion-419-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -47,6 +47,8 @@ Kubernetes: `>= 1.24.0-0 < 1.28.0-0`
 | config.coordinator.tolerations | list | `[]` |  |
 | config.general.authenticationType | string | `""` | Trino supports multiple authentication types: PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS For more info: https://trino.io/docs/current/security/authentication-types.html |
 | config.general.catalogsMountType | string | `"secret"` |  |
+| config.general.env | list | `[]` |  |
+| config.general.envFrom | list | `[]` |  |
 | config.general.http.port | int | `8080` |  |
 | config.general.httpsServer.enabled | bool | `false` |  |
 | config.general.httpsServer.keystore.key | string | `""` |  |

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -197,7 +197,7 @@ spec:
         - name: {{ .Chart.Name }}-coordinator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.config.coordinator.env }}
+          {{- if or .Values.config.general.env .Values.config.coordinator.env .Values.tls.keystorePasswordSecret }}
           env:
             {{- if or .Values.tls.keystorePasswordSecret }}
             - name: TRINO_KEYSTORE_PASSWORD
@@ -206,10 +206,12 @@ spec:
                   name: {{ .Values.tls.keystorePasswordSecret }}
                   key: keystore-password
             {{- end }}
+          {{-  tpl (toYaml .Values.config.general.env) . | nindent 12 }}
           {{-  tpl (toYaml .Values.config.coordinator.env) . | nindent 12 }}
           {{- end }}
-          {{- if .Values.config.coordinator.envFrom }}
+          {{- if or .Values.config.general.envFrom .Values.config.coordinator.envFrom }}
           envFrom:
+          {{-  tpl (toYaml .Values.config.general.envFrom) . | nindent 12 }}
           {{-  tpl (toYaml .Values.config.coordinator.envFrom) . | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -108,12 +108,14 @@ spec:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.config.worker.env }}
+          {{- if or .Values.config.general.env .Values.config.worker.env }}
           env:
+          {{-  tpl (toYaml .Values.config.general.env) . | nindent 12 }}
           {{-  tpl (toYaml .Values.config.worker.env) . | nindent 12 }}
           {{- end }}
-          {{- if .Values.config.worker.envFrom }}
+          {{- if or .Values.config.general.envFrom .Values.config.worker.envFrom }}
           envFrom:
+          {{-  tpl (toYaml .Values.config.general.envFrom) . | nindent 12 }}
           {{-  tpl (toYaml .Values.config.worker.envFrom) . | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -54,6 +54,8 @@ config:
       maxMemory: "3GB"
       maxTotalMemory: "6GB"
     prestoCompatibleHeader: false
+    env: []
+    envFrom: []
 
   coordinator:
     replicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:


**Checklist**
- [:heavy_check_mark:] Reviewed the [`CONTRIBUTING.md`](https://github.com/valeriano-manassero/helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [:heavy_check_mark:] Verify the work you plan to merge addresses an existing [issue](https://github.com/valeriano-manassero/helm-charts/issues) (If not, open a new one) (**required**)
- [:heavy_check_mark:] Check your branch with `helm lint` (**required**)
- [:heavy_check_mark:] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [:heavy_check_mark:] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifacthub changelog) (**required**)
- [:heavy_check_mark:] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

I tested the following configuration:

values.yaml
```
config:
  general:
    env:
      - name: MY-GENERAL-ENVVAR
        value: my-general-envvar-value
    envFrom:
      - configMapRef:
          name: my-general-cm

  coordinator:
    env:
      - name: MY-COORDINATOR-ENVVAR
        value: my-coordinator-envvar-value
    envFrom:
      - configMapRef:
          name: my-coordinator-cm

  worker:
    env:
      - name: MY-WORKER-ENVVAR
        value: my-worker-envvar-value
    envFrom:
      - configMapRef:
          name: my-worker-cm
```

template result

coordinator:

```
# Source: trino/templates/deployment-coordinator.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: trino-coordinator
  labels:
    helm.sh/chart: trino-6.1.0
    app.kubernetes.io/name: trino
    app.kubernetes.io/instance: trino
    app.kubernetes.io/version: "419"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: coordinator
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: trino
      app.kubernetes.io/instance: trino
      app.kubernetes.io/component: coordinator
  template:
    metadata:
      labels:
        app.kubernetes.io/name: trino
        app.kubernetes.io/instance: trino
        app.kubernetes.io/component: coordinator
      annotations:
        checksum/config: 6a674ccb29239c99f909a105b73fa8e475f139b8690604fd1a3b1d7cd9e6590a
    spec:
      securityContext:
        runAsUser: 1000
        runAsGroup: 1000
        fsGroup: 1000
      volumes:
        - name: config-volume
          projected:
            sources:
            - configMap:
                name: trino-coordinator
        - name: catalog-volume
          secret:
            secretName: trino-connectors
        - name: schemas-volume
          configMap:
            name: trino-schemas-volume-coordinator
        - name: certs-shared
          emptyDir: {}
      serviceAccountName: trino
      imagePullSecrets:
        []
      containers:
        - name: trino-coordinator
          image: "trinodb/trino:419"
          imagePullPolicy: IfNotPresent
          env:
            - name: MY-GENERAL-ENVVAR
              value: my-general-envvar-value
            - name: MY-COORDINATOR-ENVVAR
              value: my-coordinator-envvar-value
          envFrom:
            - configMapRef:
                name: my-general-cm
            - configMapRef:
                name: my-coordinator-cm
          volumeMounts:
            - mountPath: /etc/trino/
              name: config-volume
            - mountPath: /etc/trino/schemas
              name: schemas-volume
            - mountPath: /etc/trino/catalog
              name: catalog-volume
            - mountPath: /etc/trino/certs
              name: certs-shared
          ports:
            - name: http-coord
              containerPort: 8080
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /v1/status
              port: http-coord
          readinessProbe:
            httpGet:
              path: /v1/status
              port: http-coord
          resources:
            {}
```

worker:
```
# Source: trino/templates/deployment-worker.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: trino-worker
  labels:
    helm.sh/chart: trino-6.1.0
    app.kubernetes.io/name: trino
    app.kubernetes.io/instance: trino
    app.kubernetes.io/version: "419"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: worker
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: trino
      app.kubernetes.io/instance: trino
      app.kubernetes.io/component: worker
  template:
    metadata:
      labels:
        app.kubernetes.io/name: trino
        app.kubernetes.io/instance: trino
        app.kubernetes.io/component: worker
      annotations:
        checksum/config: 34e731a27e3ee1437bc9157a92da0228d7378d8a43538b41c1de98d4b7b5750b
    spec:
      securityContext:
        runAsUser: 1000
        runAsGroup: 1000
        fsGroup: 1000
      volumes:
        - name: config-volume
          projected:
            sources:
            - configMap:
                name: trino-worker
        - name: health-check-volume
          configMap:
            name: trino-worker-health-check
            defaultMode: 0777
        - name: catalog-volume
          secret:
            secretName: trino-connectors
        - name: schemas-volume
          configMap:
            name: trino-schemas-volume-worker
        - name: certs-shared
          emptyDir: {}
      serviceAccountName: trino
      imagePullSecrets:
        []
      containers:
        - name: trino-worker
          image: "trinodb/trino:419"
          imagePullPolicy: IfNotPresent
          env:
            - name: MY-GENERAL-ENVVAR
              value: my-general-envvar-value
            - name: MY-WORKER-ENVVAR
              value: my-worker-envvar-value
          envFrom:
            - configMapRef:
                name: my-general-cm
            - configMapRef:
                name: my-worker-cm
          volumeMounts:
            - mountPath: /etc/trino
              name: config-volume
            - mountPath: /etc/trino/schemas
              name: schemas-volume
            - mountPath: /startup/
              name: health-check-volume
            - mountPath: /etc/trino/catalog
              name: catalog-volume
            - mountPath: /etc/trino/certs
              name: certs-shared
          livenessProbe:
            exec:
              command:
                - /startup/health_check.sh
            initialDelaySeconds: 10
            periodSeconds: 25
          readinessProbe:
            exec:
              command:
                - /startup/health_check.sh
            initialDelaySeconds: 5
            periodSeconds: 10
          resources:
            {}
```

