### PR TITLE
Adds Lifecycle parameter for worker pods for graceful shutdown

### DIFF
--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -155,6 +155,10 @@ spec:
               containerPort: {{ .Values.jmxExporter.port | default 9000 }}
               protocol: TCP
           {{- end }}
+          {{- with .Values.config.worker.lifecycle }}
+          lifecycle:
+{{ toYaml . | nident 12 }}
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -126,6 +126,8 @@ config:
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
       stabilizationWindowSeconds: 300
+    # allows for using lifecycle hooks to set node as marked for eviction
+    lifecycle: {}
 
 eventListenerProperties: {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the required lifecycle parameter for allowing worker pods to be set as marked for graceful shutdown

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/valeriano-manassero/helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/valeriano-manassero/helm-charts/issues) (If not, open a new one) (**required**)
- [ ] Check your branch with `helm lint` (**required**)
- [ ] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [ ] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifacthub changelog) (**required**)
- [ ] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)

**Which issue(s) this PR fixes**:

Fixes #185 

**Special notes for your reviewer**:
