### PR TITLE
updating kube version to 1.30

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 appVersion: "433"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 9.1.0
-kubeVersion: ">= 1.24.0-0 < 1.29.0-0"
+version: 9.1.1
+kubeVersion: ">= 1.24.0-0 < 1.30.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
 sources:

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -19,7 +19,7 @@ High performance, distributed SQL query engine for big data
 
 ## Requirements
 
-Kubernetes: `>= 1.24.0-0 < 1.29.0-0`
+Kubernetes: `>= 1.24.0-0 < 1.30.0-0`
 
 ## Values
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a quick PR to update the required Kube version. The newest version is 1.29. This Helm chart works fine on this version.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/valeriano-manassero/helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [ ] Verify the work you plan to merge addresses an existing [issue](https://github.com/valeriano-manassero/helm-charts/issues) (If not, open a new one) (**required**)
- [ ] Check your branch with `helm lint` (**required**)
- [ ] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [ ] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifacthub changelog) (**required**)
- [ ] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:
