### PR TITLE
Feature/add extra volumes and extra volume mounts to workers

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "433"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 9.1.2
+version: 9.2.0
 kubeVersion: ">= 1.24.0-0 < 1.29.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg

--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -27,4 +27,4 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Fix worker initContainer condition so it is done on worker and not on coordinator.
+      description: Add the capability to configure extra volumes and extra volume mounts.

--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "433"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 9.1.0
+version: 9.1.2
 kubeVersion: ">= 1.24.0-0 < 1.29.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 9.1.2](https://img.shields.io/badge/Version-9.1.2-informational?style=flat-square) ![AppVersion: 433](https://img.shields.io/badge/AppVersion-433-informational?style=flat-square)
+![Version: 9.2.0](https://img.shields.io/badge/Version-9.2.0-informational?style=flat-square) ![AppVersion: 433](https://img.shields.io/badge/AppVersion-433-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 9.1.0](https://img.shields.io/badge/Version-9.1.0-informational?style=flat-square) ![AppVersion: 433](https://img.shields.io/badge/AppVersion-433-informational?style=flat-square)
+![Version: 9.1.2](https://img.shields.io/badge/Version-9.1.2-informational?style=flat-square) ![AppVersion: 433](https://img.shields.io/badge/AppVersion-433-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -72,6 +72,8 @@ Kubernetes: `>= 1.24.0-0 < 1.29.0-0`
 | config.worker.env | list | `[]` |  |
 | config.worker.envFrom | list | `[]` |  |
 | config.worker.extraConfig | string | `""` |  |
+| config.worker.extraVolumeMounts | object | `{}` |  |
+| config.worker.extraVolumes | object | `{}` |  |
 | config.worker.initContainers | list | `[]` |  |
 | config.worker.jvm.gcMethod.g1.heapRegionSize | string | `"32M"` |  |
 | config.worker.jvm.gcMethod.type | string | `"UseG1GC"` |  |

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -74,6 +74,10 @@ spec:
           configMap:
             name: {{ .configMapName }}
         {{- end }}
+        {{- range $volumeName, $volume := .Values.config.worker.extraVolumes }}
+        - name: {{ $volumeName }}
+        {{- tpl (toYaml $volume) $ | nindent 10 -}}
+        {{- end }}
       {{- if or .Values.jmxExporter.worker.enabled .Values.config.coordinator.initContainers }}
       initContainers:
       {{- if .Values.jmxExporter.worker.enabled }}
@@ -151,6 +155,10 @@ spec:
               {{- if .subPath }}
               subPath: {{ .subPath }}
               {{- end }}
+            {{- end }}
+            {{- range $mountName, $mount := .Values.config.worker.extraVolumeMounts }}
+            - name: {{ $mountName }}
+            {{- tpl (toYaml $mount) $ | nindent 14 -}}
             {{- end }}
           {{- if .Values.jmxExporter.worker.enabled }}
           ports:

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -128,6 +128,16 @@ config:
       # preStop:
       #   exec:
       #     command: ["sh", "-c", "curl -v -X PUT -d '\"SHUTTING_DOWN\"' -H \"Content-type: application/json\" -H \"X-Trino-User: admin\" http://localhost:8080/v1/info/state"]
+    extraVolumeMounts: {}
+      # sample config for temp storage volume mount
+      # localtemp:
+      #  mountpath: /tmp/localtemp
+    #  readOnly: false
+    extraVolumes: {}
+      # sample config for temp storage volume
+      # localtemp:
+      #  hostPath:
+    #    path: /mnt
 
 
 eventListenerProperties: {}

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -131,13 +131,13 @@ config:
     extraVolumeMounts: {}
       # sample config for temp storage volume mount
       # localtemp:
-      #  mountpath: /tmp/localtemp
-    #  readOnly: false
+      #   mountpath: /tmp/localtemp
+      #   readOnly: false
     extraVolumes: {}
       # sample config for temp storage volume
       # localtemp:
-      #  hostPath:
-    #    path: /mnt
+      #   hostPath:
+      #     path: /mnt
 
 
 eventListenerProperties: {}


### PR DESCRIPTION
This pr adds the capability to configure extraVolumes and extraVolumeMounts.  These can be used to mount  host local temporary storage into the worker container so it can be used as a spilling location.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/valeriano-manassero/helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [X] Verify the work you plan to merge addresses an existing [trino](https://github.com/valeriano-manassero/helm-charts/issues/198)
- [X] Check your branch with `helm lint` (**required**)
- [X] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifacthub changelog) (**required**)
- [X] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)

**Which issue(s) this PR fixes**:
Fixes #198

**Special notes for your reviewer**:
NONE