### PR TITLE
feat: add extra jmx metrics

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "433"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 10.2.0
+version: 10.3.0
 kubeVersion: ">= 1.24.0-0 < 1.31.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
@@ -27,4 +27,4 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Add extra volumes parameter to coordinator node
+      description: Add extra metrics parameter for jmx exporter

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 10.2.0](https://img.shields.io/badge/Version-10.2.0-informational?style=flat-square) ![AppVersion: 433](https://img.shields.io/badge/AppVersion-433-informational?style=flat-square)
+![Version: 10.3.0](https://img.shields.io/badge/Version-10.3.0-informational?style=flat-square) ![AppVersion: 433](https://img.shields.io/badge/AppVersion-433-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -116,6 +116,7 @@ Kubernetes: `>= 1.24.0-0 < 1.31.0-0`
 | initKeystore.image.tag | int | `17` |  |
 | jmxExporter.coordinator.enabled | bool | `false` |  |
 | jmxExporter.downloadLink | string | `"https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.17.2/jmx_prometheus_javaagent-0.17.2.jar"` |  |
+| jmxExporter.extraMetrics | object | `{}` |  |
 | jmxExporter.image.pullPolicy | string | `"IfNotPresent"` |  |
 | jmxExporter.image.repository | string | `"curlimages/curl"` |  |
 | jmxExporter.image.tag | string | `"7.87.0"` |  |

--- a/valeriano-manassero/trino/templates/configmap-jmx-exporter.yaml
+++ b/valeriano-manassero/trino/templates/configmap-jmx-exporter.yaml
@@ -60,4 +60,8 @@ data:
     - pattern : trino.execution<name=QueryManager><>UserErrorFailures.OneMinute.Count
       name: trino_failed_queries_user
 
+{{- if .Values.jmxExporter.extraMetrics }}
+{{ .Values.jmxExporter.extraMetrics | indent 4 }}
+{{- end }}
+
 {{- end }}

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -592,3 +592,4 @@ jmxExporter:
     # relabelings:
     #   - sourceLabels: [__meta_kubernetes_endpoints_label_app_kubernetes_io_version]
     #     targetLabel: version
+  extraMetrics: {}


### PR DESCRIPTION
**What this PR does / why we need it**:


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/valeriano-manassero/helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/valeriano-manassero/helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifacthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #211

**Special notes for your reviewer**:

The `extraMetrics` parameter would allow the export of extra jmx metrics like the following.

```
jmxExporter:
  extraMetrics: |
    - pattern: trino.execution<name=QueryManager><>ExecutionTime.OneMinute.P50
      name: trino_execution_time_one_minute_p50

    - pattern: trino.execution<name=QueryManager><>ExecutionTime.OneMinute.P90
      name: trino_execution_time_one_minute_p90

    - pattern: trino.execution<name=QueryManager><>ExecutionTime.OneMinute.P99
      name: trino_execution_time_one_minute_p99
```